### PR TITLE
Update Discord.Net-Example.csproj fixes #10

### DIFF
--- a/src/Discord.Net-Example.csproj
+++ b/src/Discord.Net-Example.csproj
@@ -4,6 +4,7 @@
     <OutputType>Exe</OutputType>
     <TargetFramework>netcoreapp2.0</TargetFramework>
     <RootNamespace>Example</RootNamespace>
+    <LangVersion>latest</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Set LangVersion to latest in order to avoid people having to set it manually in Visual Studio.

This fixes issue #10 