### PR TITLE
Added Microsoft.Extensions.Configuration.Yaml

### DIFF
--- a/src/Discord.Net-Example.csproj
+++ b/src/Discord.Net-Example.csproj
@@ -10,7 +10,7 @@
   <ItemGroup>
     <PackageReference Include="Discord.Net" Version="2.0.1" />
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="2.2.0" />
-    <PackageReference Include="NetEscapades.Configuration.Yaml" Version="1.6.0" />
+    <PackageReference Include="Unofficial.Microsoft.Extensions.Configuration.Yaml" Version="19.232.0.38254" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Startup.cs
+++ b/src/Startup.cs
@@ -4,6 +4,7 @@ using Discord;
 using Discord.Commands;
 using Discord.WebSocket;
 using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Configuration.Yaml;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace Example


### PR DESCRIPTION
`ConfigurationBuilder` doesn't contain a definitition for `SetBasePath()`. You need to add this reference for it to work. The NetEscapade is pretty dodgy.